### PR TITLE
check for nil pointer before dereferencing

### DIFF
--- a/pkg/api.go
+++ b/pkg/api.go
@@ -3023,9 +3023,8 @@ func GetTranslatedHttpAction(app shuffle.WorkflowApp, action shuffle.WorkflowApp
 	if action.Name == "custom_action" || action.Name == "api" || action.Name == "" {
 		return action
 	}
-
-	_, openapiSpec, err := shuffle.GetAppSingul(basepath, action.AppName) 
-	if err != nil || openapiSpec.Info.Title == "" {
+	_, openapiSpec, err := shuffle.GetAppSingul(basepath, action.AppName)
+	if err != nil || openapiSpec == nil || openapiSpec.Info == nil || openapiSpec.Info.Title == "" {
 		log.Printf("[WARNING] Failed to load openapi spec for app %s", action.AppName)
 		return action
 	}


### PR DESCRIPTION
 * When an app's OpenAPI spec fails to load (e.g., missing from datastore), GetAppSingul returns nil for openapiSpec. The existing error check attempted to access openapiSpec.Info.Title without first verifying the pointer wasn't nil, causing a panic.